### PR TITLE
Creation of script group defaults

### DIFF
--- a/wooey/migrations/0006_script_group_defaults.py
+++ b/wooey/migrations/0006_script_group_defaults.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wooey', '0005_size_bytes'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='script',
+            name='script_group',
+            field=models.ForeignKey(blank=True, to='wooey.ScriptGroup', null=True),
+        ),
+    ]

--- a/wooey/settings.py
+++ b/wooey/settings.py
@@ -1,5 +1,6 @@
 __author__ = 'chris'
 from django.conf import settings
+from django.utils.translation import gettext_lazy as _
 
 def get(key, default):
     return getattr(settings, key, default)
@@ -14,3 +15,4 @@ WOOEY_LOGIN_URL = get('WOOEY_LOGIN_URL', settings.LOGIN_URL)
 WOOEY_REGISTER_URL = get('WOOEY_REGISTER_URL', '/accounts/register/')
 WOOEY_SHOW_LOCKED_SCRIPTS = get('WOOEY_SHOW_LOCKED_SCRIPTS', True)
 WOOEY_EPHEMERAL_FILES = get('WOOEY_EPHEMERAL_FILES', False)
+WOOEY_DEFAULT_SCRIPT_GROUP = get('WOOEY_DEFAULT_SCRIPT_GROUP', _('Wooey Scripts'))


### PR DESCRIPTION
This addresses issue https://github.com/wooey/django-djangui/issues/10.

It implements a default script group for script creation, so that step can be omitted if desired. It doesn't use a default foreign key, but provides this information in the clean step of the model to avoid form validation failures due to FK null constraints.
