### PR TITLE
Support for clinto v 0.1.1 which uses a more generic api for parsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=find_packages(),
     scripts=['scripts/wooify'],
     entry_points={'console_scripts': ['wooify = wooey.backend.command_line:bootstrap',]},
-    install_requires = ['Django>=1.6', 'django-autoslug', 'django-celery', 'six', 'clinto'],
+    install_requires = ['Django>=1.6', 'django-autoslug', 'django-celery', 'six', 'clinto>=0.1.1'],
     include_package_data=True,
     description='A Django app which creates a web GUI and task interface for argparse scripts',
     url='http://www.github.com/wooey/django-djangui',

--- a/wooey/backend/utils.py
+++ b/wooey/backend/utils.py
@@ -20,7 +20,7 @@ from django.db.models import Q
 
 from celery.contrib import rdb
 
-from clinto.argparse_specs import ArgParseNodeBuilder
+from clinto.parser import Parser
 
 from .. import settings as wooey_settings
 
@@ -151,7 +151,7 @@ def add_wooey_script(script=None, group=None):
     basename, extension = os.path.splitext(script)
     filename = os.path.split(basename)[1]
 
-    parser = ArgParseNodeBuilder(script_name=filename, script_path=script)
+    parser = Parser(script_name=filename, script_path=script)
     if not parser.valid:
         return (False, parser.error)
     # make our script


### PR DESCRIPTION
This updates wooey to use clinto 0.1.1, which is a simple change in the api that is more generic.
